### PR TITLE
Support Hibernate 6.4 by replace removed method extract(statement)

### DIFF
--- a/src/main/java/com/github/marschall/hibernate/batchsequencegenerator/BatchSequenceGenerator.java
+++ b/src/main/java/com/github/marschall/hibernate/batchsequencegenerator/BatchSequenceGenerator.java
@@ -302,7 +302,7 @@ public class BatchSequenceGenerator implements BulkInsertionCapableIdentifierGen
     try (PreparedStatement statement = coordinator.getStatementPreparer().prepareStatement(this.select)) {
       statement.setFetchSize(this.fetchSize);
       statement.setInt(1, this.fetchSize);
-      try (ResultSet resultSet = coordinator.getResultSetReturn().extract(statement)) {
+      try (ResultSet resultSet = coordinator.getResultSetReturn().extract(statement, this.select)) {
         while (resultSet.next()) {
           identifiers.add(this.identifierExtractor.extractIdentifier(resultSet));
         }


### PR DESCRIPTION
Support Hibernate 6.4 by replace removed method extract(statement) with extract(statement, sql)

Fixes #15